### PR TITLE
Fix shrinked labels and deprecated syntax

### DIFF
--- a/package/contents/ui/NetworkListDetector.qml
+++ b/package/contents/ui/NetworkListDetector.qml
@@ -12,7 +12,7 @@ QtObject {
 
 	property Connections sensorConnection: Connections {
 		target: sensorData
-		onNetworkSensorListChanged: {
+		function onNetworkSensorListChanged() {
 			networkListDetector.updateNetworkModel()
 		}
 	}

--- a/package/contents/ui/PartitionUsageBar.qml
+++ b/package/contents/ui/PartitionUsageBar.qml
@@ -97,7 +97,7 @@ SimpleProgressBar {
 			return match
 		}
 
-		onSourceAdded: {
+		function onSourceAdded(source) {
 			var match = isPartitionSource(source)
 			if (match) {
 				if (match[1] == partitionPath) {
@@ -107,7 +107,7 @@ SimpleProgressBar {
 				}
 			}
 		}
-		onSourceRemoved: {
+		function onSourceRemoved(source) {
 			var match = isPartitionSource(source)
 			if (match) {
 				if (match[1] == partitionPath) {

--- a/package/contents/ui/SensorGraph.qml
+++ b/package/contents/ui/SensorGraph.qml
@@ -286,7 +286,7 @@ Item {
 
 		Connections {
 			target: sensorData
-			onDataTick: {
+			function onDataTick() {
 				var values = new Array(plotter.sensors.length)
 				for (var i = 0; i < plotter.sensors.length; i++) {
 					values[i] = sensorData.getData(sensors[i])
@@ -317,8 +317,8 @@ Item {
 		}
 		Connections {
 			target: mouseArea
-			onMouseXChanged: plotter.updateHoveredIndex()
-			onContainsMouseChanged: plotter.updateHoveredIndex()
+			function onMouseXChanged(){ plotter.updateHoveredIndex()}
+			function onContainsMouseChanged(){ plotter.updateHoveredIndex()}
 		}
 		Rectangle {
 			id: hoverLine
@@ -360,7 +360,7 @@ Item {
 				Connections {
 					target: plotter
 					enabled: tooltip.visible
-					onValuesChanged: {
+					function onValuesChanged() {
 						tooltip.updateText()
 					}
 				}

--- a/package/contents/ui/SensorGraph.qml
+++ b/package/contents/ui/SensorGraph.qml
@@ -170,7 +170,9 @@ Item {
 				leftMargin: sensorGraph.padding
 				topMargin: sensorGraph.padding
 				bottomMargin: sensorGraph.padding
-				rightMargin: sensorGraph.padding * 8
+				readonly property int freeSpace: (sensorGraph.width-legendGridLayout.width)/2
+				readonly property int defaultSpace: sensorGraph.padding*8
+				rightMargin: freeSpace>defaultSpace ? defaultSpace : freeSpace
 			}
 			// Rectangle { border.color: "#ff0"; anchors.fill: parent; color: "transparent"; border.width: 1}
 
@@ -236,7 +238,7 @@ Item {
 								Layout.preferredWidth = implicitWidth
 							}
 						}
-						Layout.maximumWidth: legendGridLayout.maxColumnWidth
+						Layout.maximumWidth: sensorGraph.width-sensorGraph.padding*4
 					}
 				}
 				

--- a/package/contents/ui/lib/AppletVersion.qml
+++ b/package/contents/ui/lib/AppletVersion.qml
@@ -31,7 +31,7 @@ Item {
 
 	Connections {
 		target: executable
-		onExited: {
+		function onExited(): {
 			version = stdout.replace('\n', ' ').trim()
 		}
 	}


### PR DESCRIPTION
![Screenshot_20210624_113002](https://user-images.githubusercontent.com/48725377/123239353-90f98800-d4df-11eb-8bdc-b9ddab031587.png)

Background rectangles were shinked in the small cpu graphs